### PR TITLE
Added createOptions scriptLoc

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -121,7 +121,8 @@ exports.create = function create(createOptions) {
         html += script;
       }
       else {
-        html = html.replace('</body>', script + '</body>');
+        var htmlTag = createOptions.scriptLoc === 'head' ? '</head>' : '</body>';
+        html = html.replace(htmlTag, script + htmlTag);
       }
 
       return html;


### PR DESCRIPTION
Adding a create option where the script, which contains __REACT_ENGINE__, can be added to the head of the html.  Ideally I would like an option to not automatically render the script tag automatically plus a function to generate the script which allows me to put it where I want in the html component manually, but this works for now.

--- Usage ---
const engine = reactEngine.server.create({
    routes: require('./routes.jsx'),
    routesFilePath: './routes.jsx',
    scriptLoc: 'head',
    page404: require('./not-found.jsx'))
  })